### PR TITLE
Added bs=1m to dd command flags

### DIFF
--- a/docs/quick-start/sd-card-setup-mac.md
+++ b/docs/quick-start/sd-card-setup-mac.md
@@ -38,11 +38,11 @@ Alternatively, you can also unmount the disk manually, by typing the following i
 
 To write the image to the SD card, the command syntax is:
 
-`dd if=[source] of=[destination]`
+`dd bs=1m if=[source] of=[destination]`
 
 so a real example of the command is:
 
-`dd if=/Users/antonypa/Desktop/RuneAudio_rpi_0.3-beta_20141029_2GB.img of=/dev/disk2`
+`dd bs=1m if=/Users/antonypa/Desktop/RuneAudio_rpi_0.3-beta_20141029_2GB.img of=/dev/disk2`
 
 if you get the following message (very likely):
 
@@ -50,7 +50,7 @@ if you get the following message (very likely):
 
 just add *sudo* in front of the command, which will prompt for your password.
  
-`sudo dd if=/Users/antonypa/Desktop/RuneAudio_rpi_0.3-beta_20141029_2GB.img of=/dev/disk2`
+`sudo dd bs=1m if=/Users/antonypa/Desktop/RuneAudio_rpi_0.3-beta_20141029_2GB.img of=/dev/disk2`
 
 After launching the command you should wait for the flashing process to complete. It can take several minutes, and you'll know that it has completed when the prompt comes back with no errors.
 


### PR DESCRIPTION
Causes DD to run orders of magnitude faster when copying an entire disk image.